### PR TITLE
Expose get_helper_indices in the public proofs API

### DIFF
--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -16,8 +16,8 @@ pub use field_inspect::*;
 pub use generalized_index::*;
 pub use node::Node;
 pub use proofs::{
-    calculate_merkle_root, calculate_multi_merkle_root, generate_proof, is_valid_merkle_branch,
-    verify_merkle_multiproof, verify_merkle_proof,
+    calculate_merkle_root, calculate_multi_merkle_root, generate_proof, get_helper_indices,
+    is_valid_merkle_branch, verify_merkle_multiproof, verify_merkle_proof,
 };
 
 pub(crate) const BYTES_PER_CHUNK: usize = 32;

--- a/ssz-rs/src/merkleization/proofs.rs
+++ b/ssz-rs/src/merkleization/proofs.rs
@@ -163,7 +163,11 @@ fn get_path_indices(tree_index: &GeneralizedIndex) -> Vec<GeneralizedIndex> {
     result
 }
 
-fn get_helper_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex> {
+/// Returns the set of sibling (helper) generalized indices required to verify a multi-Merkle
+/// proof for `indices`. Exposed so callers can validate proof shape before invoking
+/// [`calculate_multi_merkle_root`] — that function panics on a short proof, so verifiers that
+/// accept untrusted input should pre-check `proof.len() == get_helper_indices(indices).len()`.
+pub fn get_helper_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex> {
     let mut all_helper_indices = BTreeSet::new();
     let mut all_path_indices = BTreeSet::new();
 


### PR DESCRIPTION
`calculate_multi_merkle_root` panics on a short `proof` because its final `objects.get(&GeneralizedIndex(1)).unwrap()` cannot reconstruct the root. Callers that accept untrusted proof bytes (consensus light clients, bridge verifiers) need to pre-check proof length, but the helper-indices computation was previously crate-private.

Make `get_helper_indices` public and re-export it from `ssz_rs::merkleization` so verifiers can validate
`proof.len() == get_helper_indices(indices).len()` and reject malformed input with their own error type instead of panicking.