### PR TITLE
re-export get_helper_indices at the crate root

### DIFF
--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -26,8 +26,9 @@ pub use error::Error;
 pub use list::List;
 pub use merkleization::{
     calculate_merkle_root, calculate_multi_merkle_root, field_inspect, generate_proof,
-    get_generalized_index, is_valid_merkle_branch, verify_merkle_multiproof, verify_merkle_proof,
-    GeneralizedIndex, MerkleizationError, Merkleized, Node, SszReflect, SszVariableOrIndex,
+    get_generalized_index, get_helper_indices, is_valid_merkle_branch, verify_merkle_multiproof,
+    verify_merkle_proof, GeneralizedIndex, MerkleizationError, Merkleized, Node, SszReflect,
+    SszVariableOrIndex,
 };
 pub use ser::{Serialize, SerializeError};
 pub use uint::U256;


### PR DESCRIPTION
The previous commit added `pub fn get_helper_indices` and re-exported it from `merkleization::mod`, but `mod merkleization;` itself is private, so the function was not reachable from outside the crate. Add `get_helper_indices` to the `pub use merkleization::{...}` list in `lib.rs` so downstream callers can do `use ssz_rs::get_helper_indices;` alongside the other proof helpers.